### PR TITLE
Remove spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,6 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,10 +200,6 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -257,8 +253,6 @@ DEPENDENCIES
   rails (~> 7.0.0)
   sass-rails (>= 6)
   selenium-webdriver
-  spring
-  spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data


### PR DESCRIPTION
Because of this:

```
ponny@johns-mbp-2 codingcomp.io % bundle exec rails console
/Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/application.rb:103:in `block in preload': undefined method `mechanism=' for ActiveSupport::Dependencies:Module (NoMethodError)
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/railties-7.0.2.4/lib/rails/initializable.rb:32:in `instance_exec'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/railties-7.0.2.4/lib/rails/initializable.rb:32:in `run'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/railties-7.0.2.4/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:347:in `each'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:347:in `call'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/railties-7.0.2.4/lib/rails/initializable.rb:60:in `run_initializers'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/railties-7.0.2.4/lib/rails/application.rb:372:in `initialize!'
	from /Users/ponny/work/codingcomp.io/config/environment.rb:5:in `<main>'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/application.rb:106:in `preload'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/application.rb:157:in `serve'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/application.rb:145:in `block in run'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/application.rb:139:in `loop'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/application.rb:139:in `run'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from /Users/ponny/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from -e:1:in `<main>'

```

Solution taken from https://stackoverflow.com/questions/70849954/undefined-method-mechanism-for-activesupportdependenciesmodule-nomethoder